### PR TITLE
issue-40 [FE] メニューを動的に追加できるようにする

### DIFF
--- a/frontend/src/pages/register_shop/hooks.ts
+++ b/frontend/src/pages/register_shop/hooks.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
+import { FormValues } from './index.d';
 
 export const useHandler = () => {
-  const handleSubmit = useCallback((values: any) => {
+  const handleSubmit = useCallback((values: FormValues) => {
     console.log(values);
   }, []);
 

--- a/frontend/src/pages/register_shop/index.d.ts
+++ b/frontend/src/pages/register_shop/index.d.ts
@@ -1,0 +1,11 @@
+export type FormValues = {
+  name: string;
+  address: string;
+  pic?: string;
+  genre_id: string;
+  menus: Array<{
+    name: string;
+    ingredients: Array<string>;
+    pic?: string;
+  }>;
+};

--- a/frontend/src/pages/register_shop/index.tsx
+++ b/frontend/src/pages/register_shop/index.tsx
@@ -153,7 +153,11 @@ const RegisterShopPage: NextPage = memo(() => {
               </FormControl>
             </Flex>
             <Flex mb={6}>
-              <FormControl>
+              <FormControl
+                isInvalid={
+                  errors.menus && !!errors.menus[index]?.ingredients?.message
+                }
+              >
                 <Flex mb={2}>
                   <FormLabel className={styles.label}>アレルギー情報</FormLabel>
                 </Flex>
@@ -176,8 +180,19 @@ const RegisterShopPage: NextPage = memo(() => {
                         </Flex>
                       </CheckboxGroup>
                     )}
+                    rules={{
+                      validate: {
+                        atLeastOneRequired: (value) =>
+                          (value && value.length >= 1) ||
+                          '1つ以上選択してください',
+                      },
+                    }}
                   />
                 </SkeletonText>
+                <FormErrorMessage>
+                  {errors.menus &&
+                    errors.menus[index]?.ingredients?.message?.toString()}
+                </FormErrorMessage>
               </FormControl>
             </Flex>
             <Flex mb={8}>

--- a/frontend/src/pages/register_shop/index.tsx
+++ b/frontend/src/pages/register_shop/index.tsx
@@ -17,6 +17,7 @@ import { NextPage } from 'next';
 import { memo } from 'react';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 import { useHandler } from './hooks';
+import { FormValues } from './index.d';
 import styles from './index.module.scss';
 
 const RegisterShopPage: NextPage = memo(() => {
@@ -35,7 +36,7 @@ const RegisterShopPage: NextPage = memo(() => {
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
     control,
-  } = useForm({
+  } = useForm<FormValues>({
     mode: 'all',
     defaultValues: {
       name: '',


### PR DESCRIPTION
## 概要
issue: #40 

<!--
issue番号を書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
メニューは1つ以上追加されるので、動的に追加できるようにしました。
あわせてform valueの型を追加して、エラーチェックできるようにしました。
また、アレルギー情報は1つ以上選択することを必須としました。

<!--
レビュアーに重点的に見て欲しい内容を書きましょう  
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです  
-->

## 動作確認

https://user-images.githubusercontent.com/42470564/229275071-fdbd25cd-27dc-40b3-807c-8bba9f8072fb.mov


<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう  
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->

## 参考情報
- https://zenn.dev/azunasu/articles/3c35c2501dc31a
- https://qiita.com/koji-koji/items/83c0ab0f01de9e697472

<!--
参考記事の url などを記載しましょう  
-->
