### PR TITLE
[FE] 原材料がなくても保存できるようにする

### DIFF
--- a/frontend/src/features/RegisterShop/Ingredients/index.tsx
+++ b/frontend/src/features/RegisterShop/Ingredients/index.tsx
@@ -54,12 +54,6 @@ const Ingredients = ({ errors, control, index }: Props) => {
               </Flex>
             </CheckboxGroup>
           )}
-          rules={{
-            validate: {
-              atLeastOneRequired: (value) =>
-                (value && value.length >= 1) || '1つ以上選択してください',
-            },
-          }}
         />
       </SkeletonText>
       <FormErrorMessage>


### PR DESCRIPTION
## 概要
issue: #181 

<!--
issue番号を書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細

アレルギー表にアレルギー物質がないメニューが存在する。
そのメニューも登録ができるようにアレルギー物質のチェックがされているかどうかのバリデーションを削除した。

<!--
レビュアーに重点的に見て欲しい内容を書きましょう  
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです  
-->

## 動作確認

https://github.com/centerRyo/ohgetsu/assets/42470564/15740390-fd7c-4499-ac3e-e427e5e2b99e



<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう  
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください  
-->

## 参考情報

<!--
参考記事の url などを記載しましょう  
-->
